### PR TITLE
Use numpy instead of pyopencl

### DIFF
--- a/test/test_sampling.py
+++ b/test/test_sampling.py
@@ -109,7 +109,7 @@ def main():
     qy = 4
     qz = 4
     
-    query_point = actx.from_numpy(np.array([qx, qy, qz]))
+    query_point = np.array([qx, qy, qz])
     u_query = simple_poly(qx,qy,qz)
     tol = 1e-5
     


### PR DESCRIPTION
I wasn't thinking about this the right way; we don't necessarily need to use PyOpenCL here since the unit nodes only need to get computed once (also, it would be a pain to do since we would have to rewrite most of `_get_query_map`). This numpy version seems to work the same as the previous PyOpenCL version.